### PR TITLE
Prevent client_secret from being stored in tfstate

### DIFF
--- a/resource_client.go
+++ b/resource_client.go
@@ -23,10 +23,6 @@ func resourceClient() *schema.Resource {
 				Type:     schema.TypeString,
 				Computed: true,
 			},
-			"client_secret": &schema.Schema{
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"name": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,


### PR DESCRIPTION
This is slightly controversial so I put it in a seperate PR.

I don't think the client_secret should exist in the tfstate file, it's too hard to secure. My preference is to just not store it at all or output it.