### PR TITLE
Modifying Provider to Use Client ID/Client Secret

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.8.x
+- 1.9.x
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.9.x
+- 1.10.x
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ go:
 sudo: false
 
 install:
-- go get ./...
+- go get -t -v ./...
 
 script:
 - make test

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Provides an auth0 client
 ```hcl
 provider "auth0" {
     domain = "abc.eu.auth0.com"
-    access_token = "management.access.token"
+    client_id = "<CLIENT_ID>"
+    client_secret = "<CLIENT_SECRET>"
 }
 
 resource "auth0_client" "test-client" {
@@ -46,11 +47,15 @@ resource.auth0_client.test-client.client_secret = "generated_client_secret"
 #### Argument Reference
 
 Arguments have the same names as provided in Auth0 Management API documentation (https://auth0.com/docs/api/management/v2#!/Clients).
-The provider itself requires 2 parameters:
+
+The provider itself requires 3 parameters:
 
 
 - `domain` - The provided domain for the Auth0 account
-- `access_token` - An access token with sufficient permissions to access the Auth0 Management API and perform CRUD operations on clients
+- `client_id` - The client ID for the Application
+- `client_secret` - The client secret for the Applicaton.
+
+You can consult [the Auth0 Documentation](https://auth0.com/docs/api/management/v2/tokens#1-create-and-authorize-an-application) for steps on creating a Machine-to-Machine Application in your Auth0 tenant with access to its Auth0 Management API.
 
 #### Attributes Reference
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ The provider itself requires 3 parameters:
 
 You can consult [the Auth0 Documentation](https://auth0.com/docs/api/management/v2/tokens#1-create-and-authorize-an-application) for steps on creating a Machine-to-Machine Application in your Auth0 tenant with access to its Auth0 Management API.
 
+Optionally, you may also manually specify a token using the `access_token` parameter:
+
+```
+provider "auth0" {
+    domain = "abc.eu.auth0.com"
+    access_token = "<ACCESS_TOKEN>"
+}
+```
+
+When you do this, the provider will not request a token on your behalf.
+
 #### Attributes Reference
 
 - `client_id` - The client ID of the new client

--- a/provider.go
+++ b/provider.go
@@ -75,7 +75,6 @@ func providerConfigureRaw(client *http.Client, domain string, clientId string, c
 		return nil, errors.New(message)
 	}
 
-
 	// for the sake of compatibility, make sure you can still use the token if you've got it.
 	if accessToken != "" {
 		log.Printf("[INFO] Skipping token request, token already present.")

--- a/provider.go
+++ b/provider.go
@@ -3,11 +3,11 @@ package main
 import (
 	"log";
 
-	"github.com/hashicorp/terraform/helper/schema";
-	"io/ioutil";
-	"strings";
-	"net/http";
-	"encoding/json";
+	"github.com/hashicorp/terraform/helper/schema"
+	"io/ioutil"
+	"strings"
+	"net/http"
+	"encoding/json"
 	"errors"
 	"strconv"
 )

--- a/provider.go
+++ b/provider.go
@@ -1,15 +1,15 @@
 package main
 
 import (
-	"log";
+	"log"
 
-	"github.com/hashicorp/terraform/helper/schema"
-	"io/ioutil"
-	"strings"
-	"net/http"
 	"encoding/json"
 	"errors"
+	"github.com/hashicorp/terraform/helper/schema"
+	"io/ioutil"
+	"net/http"
 	"strconv"
+	"strings"
 )
 
 func Provider() *schema.Provider {
@@ -21,8 +21,8 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("MANAGEMENT_API_DOMAIN", nil),
 			},
 			"client_id": &schema.Schema{
-				Type:		 schema.TypeString,
-				Required:	 true,
+				Type:        schema.TypeString,
+				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("MANAGEMENT_API_CLIENT_ID", nil),
 			},
 			"client_secret": &schema.Schema{
@@ -42,15 +42,15 @@ func Provider() *schema.Provider {
 }
 
 type Config struct {
-	domain       string
-	accessToken  string
+	domain      string
+	accessToken string
 }
 
 type Auth0Token struct {
 	AccessToken string `json:"access_token"`
-	ExpiresIn int `json:"expires_in"`
-	Scope string `json:"scope"`
-	TokenType string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+	TokenType   string `json:"token_type"`
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
@@ -58,16 +58,16 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	domain := d.Get("domain").(string)
 	clientSecret := d.Get("client_secret").(string)
 	clientId := d.Get("client_id").(string)
-	
+
 	return providerConfigureRaw(http.DefaultClient, domain, clientId, clientSecret)
 }
 
-func providerConfigureRaw(client *http.Client, domain string, clientId string, clientSecret string) (interface{}, error){
+func providerConfigureRaw(client *http.Client, domain string, clientId string, clientSecret string) (interface{}, error) {
 	url := "https://" + domain + "/oauth/token"
-	
+
 	payload := strings.NewReader(`{ "grant_type": "client_credentials", ` +
-		`"client_id": "` + clientId +  `", ` +
-		`"client_secret": "` + clientSecret + `", ` + 
+		`"client_id": "` + clientId + `", ` +
+		`"client_secret": "` + clientSecret + `", ` +
 		`"audience": "https://` + domain + `/api/v2/"}`)
 
 	req, _ := http.NewRequest("POST", url, payload)
@@ -103,5 +103,5 @@ func providerConfigureRaw(client *http.Client, domain string, clientId string, c
 
 	log.Printf("[DEBUG] Domain is %s, token is %s", domain, auth0Token.AccessToken)
 
-	return Config{ domain: domain, accessToken: auth0Token.AccessToken}, nil
+	return Config{domain: domain, accessToken: auth0Token.AccessToken}, nil
 }

--- a/provider.go
+++ b/provider.go
@@ -8,6 +8,8 @@ import (
 	"strings";
 	"net/http";
 	"encoding/json";
+	"errors"
+	"strconv"
 )
 
 func Provider() *schema.Provider {
@@ -54,30 +56,52 @@ type Auth0Token struct {
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	log.Println("[INFO] Initializing Auth0 client")
 	domain := d.Get("domain").(string)
-	client_secret := d.Get("client_secret").(string)
-	client_id := d.Get("client_id").(string)
+	clientSecret := d.Get("client_secret").(string)
+	clientId := d.Get("client_id").(string)
 	
+	return providerConfigureRaw(http.DefaultClient, domain, clientId, clientSecret)
+}
+
+func providerConfigureRaw(client *http.Client, domain string, clientId string, clientSecret string) (interface{}, error){
 	url := "https://" + domain + "/oauth/token"
 	
 	payload := strings.NewReader(`{ "grant_type": "client_credentials", ` +
-		`"client_id": "` + client_id +  `", ` +
-		`"client_secret": "` + client_secret + `", ` + 
-		`"audience": "https://` + domain + `/api/v2"}`)
+		`"client_id": "` + clientId +  `", ` +
+		`"client_secret": "` + clientSecret + `", ` + 
+		`"audience": "https://` + domain + `/api/v2/"}`)
 
 	req, _ := http.NewRequest("POST", url, payload)
 	req.Header.Add("content-type", "application/json")
-	req.Header.Add("content-type", "application/json")
 
-	res, _ := http.DefaultClient.Do(req)
+	res, postErr := client.Do(req)
+	if postErr != nil {
+		log.Printf("[ERROR] Failed to contact Auth0 API: %s", postErr)
+		return Config{}, postErr
+	}
 
 	defer res.Body.Close()
-	body, _ := ioutil.ReadAll(res.Body)
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		log.Printf("[ERROR] Failed to read Response: %s", err)
+		return Config{}, err
+	}
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		log.Printf("[ERROR] Received HTTP Response Code %d from %s: %s", res.StatusCode, url, body)
+		errorText := url + ` responded with code ` + strconv.Itoa(res.StatusCode) + `: ` + string(body)
+		return Config{}, errors.New(errorText)
+	}
+
+	log.Printf("[DEBUG] Response was: %s", body)
 
 	var auth0Token Auth0Token
-	err := json.Unmarshal(body, &auth0Token)
-	if err != nil {
-		log.Println("[ERROR] Failed to Unmarshal Auth0 Response")
+	unmarshalErr := json.Unmarshal(body, &auth0Token)
+	if unmarshalErr != nil {
+		log.Printf("[ERROR] Failed to Unmarshal Auth0 Response: %s", unmarshalErr)
+		return Config{}, unmarshalErr
 	}
+
+	log.Printf("[DEBUG] Domain is %s, token is %s", domain, auth0Token.AccessToken)
 
 	return Config{ domain: domain, accessToken: auth0Token.AccessToken}, nil
 }

--- a/provider.go
+++ b/provider.go
@@ -1,9 +1,13 @@
 package main
 
 import (
-	"log"
+	"log";
 
-	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/helper/schema";
+	"io/ioutil";
+	"strings";
+	"net/http";
+	"encoding/json";
 )
 
 func Provider() *schema.Provider {
@@ -14,10 +18,15 @@ func Provider() *schema.Provider {
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("MANAGEMENT_API_DOMAIN", nil),
 			},
-			"access_token": &schema.Schema{
+			"client_id": &schema.Schema{
+				Type:		 schema.TypeString,
+				Required:	 true,
+				DefaultFunc: schema.EnvDefaultFunc("MANAGEMENT_API_CLIENT_ID", nil),
+			},
+			"client_secret": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
-				DefaultFunc: schema.EnvDefaultFunc("MANAGEMENT_API_ACCESS_TOKEN", nil),
+				DefaultFunc: schema.EnvDefaultFunc("MANAGEMENT_API_CLIENT_SECRET", nil),
 			},
 		},
 
@@ -31,11 +40,45 @@ func Provider() *schema.Provider {
 }
 
 type Config struct {
-	domain      string
-	accessToken string
+	domain       string
+	accessToken  string
+}
+
+type Auth0Token struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn int `json:"expires_in"`
+	Scope string `json:"scope"`
+	TokenType string `json:"token_type"`
 }
 
 func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	log.Println("[INFO] Initializing Auth0 client")
-	return Config{domain: d.Get("domain").(string), accessToken: d.Get("access_token").(string)}, nil
+	domain := d.Get("domain").(string)
+	client_secret := d.Get("client_secret").(string)
+	client_id := d.Get("client_id").(string)
+	
+	url := "https://" + domain + "/oauth/token"
+	
+	// payload := strings.NewReader("{\"grant_type\":\"client_credentials\",\"client_id\": \"rOlwtvTBtmNER5AsdTgx1Xjd3gnRHapW\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"audience\": \"https://quanticmind.auth0.com/api/v2/\"}")
+	payload := strings.NewReader(`{ "grant_type": "client_credentials", ` +
+		`"client_id": "` + client_id +  `", ` +
+		`"client_secret": "` + client_secret + `", ` + 
+		`"audience": "https://` + domain + `/api/v2"}`)
+
+	req, _ := http.NewRequest("POST", url, payload)
+	req.Header.Add("content-type", "application/json")
+	req.Header.Add("content-type", "application/json")
+
+	res, _ := http.DefaultClient.Do(req)
+
+	defer res.Body.Close()
+	body, _ := ioutil.ReadAll(res.Body)
+
+	var auth0Token Auth0Token
+	err := json.Unmarshal(body, &auth0Token)
+	if err != nil {
+		log.Println("[ERROR] Failed to Unmarshal Auth0 Response")
+	}
+
+	return Config{ domain: domain, accessToken: auth0Token.AccessToken}, nil
 }

--- a/provider.go
+++ b/provider.go
@@ -59,7 +59,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 	
 	url := "https://" + domain + "/oauth/token"
 	
-	// payload := strings.NewReader("{\"grant_type\":\"client_credentials\",\"client_id\": \"rOlwtvTBtmNER5AsdTgx1Xjd3gnRHapW\",\"client_secret\": \"YOUR_CLIENT_SECRET\",\"audience\": \"https://quanticmind.auth0.com/api/v2/\"}")
 	payload := strings.NewReader(`{ "grant_type": "client_credentials", ` +
 		`"client_id": "` + client_id +  `", ` +
 		`"client_secret": "` + client_secret + `", ` + 

--- a/provider_test.go
+++ b/provider_test.go
@@ -30,9 +30,18 @@ func TestProviderConfigRawSad(t *testing.T) {
 	defer testServer.Close()
 
 	testDomain := testServer.URL[8:]
-	result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret)
+	result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret, "")
 	assert.Equal(Config{}, result)
 
+}
+
+func TestProviderConfigWithToken(t *testing.T) {
+	assert := assert.New(t)
+
+	result, err := providerConfigureRaw(http.DefaultClient, "contoso.auth0.com", "", "", "not_a_real_token")
+	assert.Equal("contoso.auth0.com", result.(Config).domain)
+	assert.Equal("not_a_real_token", result.(Config).accessToken)
+	assert.Equal(err, nil)
 }
 
 func TestProviderConfigRaw(t *testing.T) {
@@ -74,7 +83,7 @@ func TestProviderConfigRaw(t *testing.T) {
 	defer testServer.Close()
 
 	testDomain := testServer.URL[8:]
-	result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret)
+	result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret, "")
 
 	assert.Equal(1, times)
 	assert.Equal(testDomain, result.(Config).domain)

--- a/provider_test.go
+++ b/provider_test.go
@@ -18,12 +18,6 @@ type ClientRequest struct {
     Audience string `json:"audience"`
 }
 
-func TestProvider(t *testing.T) {
-    if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
-        t.Fatalf("err: %s", err)
-    }
-}
-
 func TestProviderConfigRawSad(t *testing.T) {
     assert := assert.New(t)
     clientSecret := "cauliflower"

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+    "net/http/httptest"
+    "net/http"
+    "testing"
+    "github.com/stretchr/testify/assert"
+    "encoding/json"
+    "io/ioutil"
+    "fmt"
+)
+
+type ClientRequest struct {
+    GrantType string `json:"grant_type"`
+    ClientId string `json:"client_id"`
+    ClientSecret string `json:"client_secret"`
+    Audience string `json:"audience"`
+}
+
+// func TestProvider(t *testing.T) {
+//     if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+//         t.Fatalf("err: %s", err)
+//     }
+// }
+
+func TestProviderConfigRawSad(t *testing.T) {
+    assert := assert.New(t)
+    clientSecret := "cauliflower"
+    clientId := "joebang"   
+
+    testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(400)
+        w.Header().Set("content-type", "application/json")
+        fmt.Fprintf(w, `{"error":"access_denied","error_description":"Service not enabled within domain: https://dshbreak.auth0.com/api/v2/"}`)
+    }))
+    defer testServer.Close()
+
+    testDomain := testServer.URL[8:]
+    result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret)
+    assert.Equal(Config{}, result)
+
+}
+
+func TestProviderConfigRaw(t *testing.T) {
+    assert := assert.New(t)
+
+    times := 0
+    clientSecret := "cauliflower"
+    clientId := "joebang"   
+    token := "wubbalubbadubdub"
+    
+    testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        times++
+        assert.Equal("POST", r.Method)
+        body, readErr := ioutil.ReadAll(r.Body)
+        if readErr != nil {
+            t.Fatalf("Failed to read request: %s", readErr)
+        }
+        
+        var clientRequest ClientRequest
+        unmarshalErr := json.Unmarshal(body, &clientRequest)
+        if unmarshalErr != nil {
+            t.Fatalf("Failed to parse request: %s", unmarshalErr)
+        }
+
+        assert.Equal(clientSecret, clientRequest.ClientSecret)
+        assert.Equal(clientId, clientRequest.ClientId)
+        assert.Equal("client_credentials", clientRequest.GrantType)
+
+        clientResponse := &Auth0Token{
+            AccessToken: token,
+            ExpiresIn: 86400,
+            Scope: "superman:all",
+            TokenType: "type",
+        }
+
+        w.WriteHeader(200)
+        json.NewEncoder(w).Encode(clientResponse)
+    }))
+    defer testServer.Close()
+
+    testDomain := testServer.URL[8:]
+    result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret)
+
+    assert.Equal(1, times)
+    assert.Equal(testDomain, result.(Config).domain)
+    assert.Equal(token, result.(Config).accessToken)
+}

--- a/provider_test.go
+++ b/provider_test.go
@@ -8,7 +8,6 @@ import (
     "encoding/json"
     "io/ioutil"
     "fmt"
-    "github.com/hashicorp/terraform/helper/schema"
 )
 
 type ClientRequest struct {

--- a/provider_test.go
+++ b/provider_test.go
@@ -8,6 +8,7 @@ import (
     "encoding/json"
     "io/ioutil"
     "fmt"
+    "github.com/hashicorp/terraform/helper/schema"
 )
 
 type ClientRequest struct {
@@ -17,11 +18,11 @@ type ClientRequest struct {
     Audience string `json:"audience"`
 }
 
-// func TestProvider(t *testing.T) {
-//     if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
-//         t.Fatalf("err: %s", err)
-//     }
-// }
+func TestProvider(t *testing.T) {
+    if err := Provider().(*schema.Provider).InternalValidate(); err != nil {
+        t.Fatalf("err: %s", err)
+    }
+}
 
 func TestProviderConfigRawSad(t *testing.T) {
     assert := assert.New(t)

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,82 +1,82 @@
 package main
 
 import (
-    "net/http/httptest"
-    "net/http"
-    "testing"
-    "github.com/stretchr/testify/assert"
-    "encoding/json"
-    "io/ioutil"
-    "fmt"
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
 )
 
 type ClientRequest struct {
-    GrantType string `json:"grant_type"`
-    ClientId string `json:"client_id"`
-    ClientSecret string `json:"client_secret"`
-    Audience string `json:"audience"`
+	GrantType    string `json:"grant_type"`
+	ClientId     string `json:"client_id"`
+	ClientSecret string `json:"client_secret"`
+	Audience     string `json:"audience"`
 }
 
 func TestProviderConfigRawSad(t *testing.T) {
-    assert := assert.New(t)
-    clientSecret := "cauliflower"
-    clientId := "joebang"   
+	assert := assert.New(t)
+	clientSecret := "cauliflower"
+	clientId := "joebang"
 
-    testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        w.WriteHeader(400)
-        w.Header().Set("content-type", "application/json")
-        fmt.Fprintf(w, `{"error":"access_denied","error_description":"Service not enabled within domain: https://dshbreak.auth0.com/api/v2/"}`)
-    }))
-    defer testServer.Close()
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Header().Set("content-type", "application/json")
+		fmt.Fprintf(w, `{"error":"access_denied","error_description":"Service not enabled within domain: https://dshbreak.auth0.com/api/v2/"}`)
+	}))
+	defer testServer.Close()
 
-    testDomain := testServer.URL[8:]
-    result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret)
-    assert.Equal(Config{}, result)
+	testDomain := testServer.URL[8:]
+	result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret)
+	assert.Equal(Config{}, result)
 
 }
 
 func TestProviderConfigRaw(t *testing.T) {
-    assert := assert.New(t)
+	assert := assert.New(t)
 
-    times := 0
-    clientSecret := "cauliflower"
-    clientId := "joebang"   
-    token := "wubbalubbadubdub"
-    
-    testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-        times++
-        assert.Equal("POST", r.Method)
-        body, readErr := ioutil.ReadAll(r.Body)
-        if readErr != nil {
-            t.Fatalf("Failed to read request: %s", readErr)
-        }
-        
-        var clientRequest ClientRequest
-        unmarshalErr := json.Unmarshal(body, &clientRequest)
-        if unmarshalErr != nil {
-            t.Fatalf("Failed to parse request: %s", unmarshalErr)
-        }
+	times := 0
+	clientSecret := "cauliflower"
+	clientId := "joebang"
+	token := "wubbalubbadubdub"
 
-        assert.Equal(clientSecret, clientRequest.ClientSecret)
-        assert.Equal(clientId, clientRequest.ClientId)
-        assert.Equal("client_credentials", clientRequest.GrantType)
+	testServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		times++
+		assert.Equal("POST", r.Method)
+		body, readErr := ioutil.ReadAll(r.Body)
+		if readErr != nil {
+			t.Fatalf("Failed to read request: %s", readErr)
+		}
 
-        clientResponse := &Auth0Token{
-            AccessToken: token,
-            ExpiresIn: 86400,
-            Scope: "superman:all",
-            TokenType: "type",
-        }
+		var clientRequest ClientRequest
+		unmarshalErr := json.Unmarshal(body, &clientRequest)
+		if unmarshalErr != nil {
+			t.Fatalf("Failed to parse request: %s", unmarshalErr)
+		}
 
-        w.WriteHeader(200)
-        json.NewEncoder(w).Encode(clientResponse)
-    }))
-    defer testServer.Close()
+		assert.Equal(clientSecret, clientRequest.ClientSecret)
+		assert.Equal(clientId, clientRequest.ClientId)
+		assert.Equal("client_credentials", clientRequest.GrantType)
 
-    testDomain := testServer.URL[8:]
-    result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret)
+		clientResponse := &Auth0Token{
+			AccessToken: token,
+			ExpiresIn:   86400,
+			Scope:       "superman:all",
+			TokenType:   "type",
+		}
 
-    assert.Equal(1, times)
-    assert.Equal(testDomain, result.(Config).domain)
-    assert.Equal(token, result.(Config).accessToken)
+		w.WriteHeader(200)
+		json.NewEncoder(w).Encode(clientResponse)
+	}))
+	defer testServer.Close()
+
+	testDomain := testServer.URL[8:]
+	result, _ := providerConfigureRaw(testServer.Client(), testDomain, clientId, clientSecret)
+
+	assert.Equal(1, times)
+	assert.Equal(testDomain, result.(Config).domain)
+	assert.Equal(token, result.(Config).accessToken)
 }


### PR DESCRIPTION
We're intending to use Terraform with Auth0 in fully automated contexts (i.e. Jenkins), so we wanted the Provider to be able to request a token using a Client ID and Client Secret. These changes modify the provider to use the client_id and client_secret. This change _should_ be backwards compatible with existing Terraform code.

I also added unit tests to prove out my changes. Travis CI shows a succesful run [here](https://travis-ci.org/dishbreak/terraform-provider-auth0).